### PR TITLE
Fixing debian version to strecth

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # VERSION 1.0.1
 
 #what image to use
-FROM debian
+FROM debian:stretch
 
 #maintainer
 MAINTAINER Herbert Steininger <hsteininger@hsteininger.de>


### PR DESCRIPTION
The latest tag of debian refers to the new release "buster" of debian, which does not have the package "lsb" anymore.